### PR TITLE
recreate the seastone wdt issue PR

### DIFF
--- a/tests/platform_tests/api/watchdog.yml
+++ b/tests/platform_tests/api/watchdog.yml
@@ -62,3 +62,9 @@ x86_64-arista.*:
     valid_timeout: 10
     greater_timeout: 100
     too_big_timeout: 660
+
+x86_64-cel_seastone-r0:
+  default:
+    valid_timeout: 10
+    greater_timeout: 20
+    too_big_timeout: 16779

--- a/tests/platform_tests/api/watchdog.yml
+++ b/tests/platform_tests/api/watchdog.yml
@@ -63,6 +63,7 @@ x86_64-arista.*:
     greater_timeout: 100
     too_big_timeout: 660
 
+# Celestica Seastone watchdog
 x86_64-cel_seastone-r0:
   default:
     valid_timeout: 10


### PR DESCRIPTION
## # Summary:
Fixes watchdog platform testbed test case too_big_timeout issue in celestica seastone.

### Type of change:
Add the definiation of too_big_timeout value in watchdog.yml which will be used to compare to the seastone watchdog max time setting.

How did you do it?
1 Add the definiation of too_big_timeout value in watchdog.yml which will be used to compare to the seastone watchdog max time setting.
2 Add the too_big_timeout checking in watchdog.py of seastone DUT platform definiation.
If the too_big_timeout value is bigger than the watchdog max time setting value, test case will return Error which is expected test result.

How did you verify/test it?
Through running Testbed pytest platform watchdog test case.

Any platform specific information?
celestica seastone-r0 platform

Supported testbed topology if it's a new test case?
yes.

